### PR TITLE
fix: remove validation for fullList

### DIFF
--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
-            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json
+            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation
           - name: Arb1 Arbify Uniswap
             command: yarn arbify --l2NetworkID 42161 --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
           - name: Arb1 Arbify Gemini
@@ -90,7 +90,7 @@ jobs:
           - name: ArbGoerli Arbify CMC
             command: yarn arbify --l2NetworkID 421613 --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
           - name: ArbGoerli FullList
-            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json
+            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -211,25 +211,6 @@ describe('Token Lists', () => {
     });
   });
 
-  describe('fullList', () => {
-    it('should generate fullList for a given network', async () => {
-      expect.assertions(1);
-      const [localList, onlineList] = await Promise.all([
-        runCommand(Action.Full, [
-          '--l2NetworkID=42161',
-          '--tokenList=full',
-          '--ignorePreviousList=true',
-          '--newArbifiedList=./src/ArbTokenLists/all_tokens.json',
-        ]),
-        fetch(
-          'https://tokenlist.arbitrum.io/ArbTokenLists/arbed_full.json',
-        ).then((response) => response.json()),
-      ]);
-
-      compareLists(localList, onlineList);
-    });
-  });
-
   describe('allTokensList', () => {
     it.skip('should generate allTokensList for a given network', async () => {
       expect.assertions(2);


### PR DESCRIPTION
Fix issues with fullList failing on validation for Arb1.
Full lists don't include symbols or names, so validation is irrelevant for those cases.




