### PR TITLE
fix: Make previous list mandatory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,4 +10,10 @@ module.exports = {
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
   },
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { ignoreRestSiblings: true },
+    ],
+  },
 };

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -61,9 +61,9 @@ jobs:
           #   command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
-            paths: |-
-              ArbTokenLists/arbed_uniswap_labs.json
-              ArbTokenLists/arbed_uniswap_labs_default.json
+            paths: |
+              - ArbTokenLists/arbed_uniswap_labs.json
+              - ArbTokenLists/arbed_uniswap_labs_default.json
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,7 +141,7 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version | jq 'join(".")'
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version | jq 'join(".")')
           if [[ -n $version ]]; then
             echo "onlineVersion=$version" >> $GITHUB_OUTPUT
           else
@@ -153,7 +153,7 @@ jobs:
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version | jq 'join(".")'
+          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version | jq 'join(".")')
           if [[ -n $version ]]; then
             echo "newVersion=$version" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ matrix.commands.paths }}
+          paths=${{ fromJson(matrix.commands.paths) }}
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' }}
-        run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}
+        run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
 
       - name: Deploy (Test folder)
         if: ${{ inputs.environment == 'Test' }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ fromJson(matrix.commands.paths) }}
+          paths=${{ join(matrix.commands.paths, ' ') }}
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,15 +141,25 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/ | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
-          echo "onlineVersion=$version" >> $GITHUB_OUTPUT
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          if [[ -n $version ]]; then
+            echo "onlineVersion=$version" >> $GITHUB_OUTPUT
+          else
+            # Make sure failure from curl, jq or awk fails the generation
+            exit 1
+          fi
 
       - name: Get new version
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
           version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
-          echo "newVersion=$version" >> $GITHUB_OUTPUT
+          if [[ -n $version ]]; then
+            echo "newVersion=$version" >> $GITHUB_OUTPUT
+          else
+            # Make sure failure from curl, jq or awk fails the generation
+            exit 1
+          fi
 
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -153,7 +153,7 @@ jobs:
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ matrix.commands.paths[2] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           if [[ -n $version ]]; then
             echo "newVersion=$version" >> $GITHUB_OUTPUT
           else
@@ -164,7 +164,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=(${{ join(matrix.commands.paths, ' ') }})
+          paths=(${{ 'a' }})
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -61,11 +61,9 @@ jobs:
           #   command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
-            paths: |
-              (
-                ArbTokenLists/arbed_uniswap_labs.json
-                ArbTokenLists/arbed_uniswap_labs_default.json
-              )
+            paths:
+              - ArbTokenLists/arbed_uniswap_labs.json
+              - ArbTokenLists/arbed_uniswap_labs_default.json
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
-            path:
+            paths:
               - ArbTokenLists/arbed_full.json
             version: false
             command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
@@ -69,50 +69,50 @@ jobs:
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
           - name: Arb1 Arbify Gemini
-            path: |
+            paths:
               - ArbTokenLists/arbed_gemini_token_list.json
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
 
           - name: Arb1 Arbify CMC
-            path:
+            paths:
               - ArbTokenLists/arbed_coinmarketcap.json
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
 
           - name: Arb1 Update Whitelist
-            path:
+            paths:
               - ArbTokenLists/arbed_arb_whitelist_era.json
             version: true
             command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
-            path:
+            paths:
               - ArbTokenLists/42170_arbed_uniswap_labs.json
               - ArbTokenLists/42170_arbed_uniswap_labs_default.json
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
           - name: ArbNova Arbify Gemini
-            path:
+            paths:
               - ArbTokenLists/42170_arbed_gemini_token_list.json
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
 
           - name: ArbNova Arbify CMC
-            path:
+            paths:
               - ArbTokenLists/42170_arbed_coinmarketcap.json
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
-            path:
+            paths:
               - ArbTokenLists/421613_arbed_coinmarketcap.json
             version: true
             command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
 
           - name: ArbGoerli FullList
-            path:
+            paths:
               - ArbTokenLists/421613_arbed_full.json
             version: false
             command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -55,63 +55,62 @@ jobs:
       fail-fast: false
       matrix:
         commands:
-          - name: Arb1 FullList
-            path: [ArbTokenLists/arbed_full.json]
-            version: false
-            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
+          # - name: Arb1 FullList
+          #   path: [ArbTokenLists/arbed_full.json]
+          #   version: false
+          #   command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
-            path: |
-              [
-                ArbTokenLists/arbed_uniswap_labs.json
-                ArbTokenLists/arbed_uniswap_labs_default.json
-              ]
+            paths: |
+              {
+                \"paths\": [ArbTokenLists/arbed_uniswap_labs.json, ArbTokenLists/arbed_uniswap_labs_default.json]
+              }
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
-          - name: Arb1 Arbify Gemini
-            path: [ArbTokenLists/arbed_gemini_token_list.json]
-            version: true
-            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
+          # - name: Arb1 Arbify Gemini
+          #   path: [ArbTokenLists/arbed_gemini_token_list.json]
+          #   version: true
+          #   command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
 
-          - name: Arb1 Arbify CMC
-            path: [ArbTokenLists/arbed_coinmarketcap.json]
-            version: true
-            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
+          # - name: Arb1 Arbify CMC
+          #   path: [ArbTokenLists/arbed_coinmarketcap.json]
+          #   version: true
+          #   command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
 
-          - name: Arb1 Update Whitelist
-            path: [ArbTokenLists/arbed_arb_whitelist_era.json]
-            version: true
-            command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
+          # - name: Arb1 Update Whitelist
+          #   path: [ArbTokenLists/arbed_arb_whitelist_era.json]
+          #   version: true
+          #   command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
-          - name: ArbNova Arbify Uniswap
-            path: |
-              [
-                ArbTokenLists/42170_arbed_uniswap_labs.json
-                ArbTokenLists/42170_arbed_uniswap_labs_default.json
-              ]
-            version: true
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+          # - name: ArbNova Arbify Uniswap
+          #   path: |
+          #     [
+          #       ArbTokenLists/42170_arbed_uniswap_labs.json
+          #       ArbTokenLists/42170_arbed_uniswap_labs_default.json
+          #     ]
+          #   version: true
+          #   command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
-          - name: ArbNova Arbify Gemini
-            path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
-            version: true
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
+          # - name: ArbNova Arbify Gemini
+          #   path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
+          #   version: true
+          #   command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
 
-          - name: ArbNova Arbify CMC
-            path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
-            version: true
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
+          # - name: ArbNova Arbify CMC
+          #   path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
+          #   version: true
+          #   command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
-          - name: ArbGoerli Arbify CMC
-            path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
-            version: true
-            command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
+          # - name: ArbGoerli Arbify CMC
+          #   path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
+          #   version: true
+          #   command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
 
-          - name: ArbGoerli FullList
-            path: [ArbTokenLists/421613_arbed_full.json]
-            version: false
-            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
+          # - name: ArbGoerli FullList
+          #   path: [ArbTokenLists/421613_arbed_full.json]
+          #   version: false
+          #   command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'
@@ -144,13 +143,13 @@ jobs:
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=(${{ join(matrix.commands.path, ', ') }})
+          paths=${{ toJson(matrix.commands.paths).paths }}
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
@@ -162,7 +161,7 @@ jobs:
 
       # - name: Backup
       #   if: ${{ inputs.environment == 'CI' && matrix.commands.version == true }}
-      #   run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
+      #   run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.paths[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
 
       - name: Deploy
         if: ${{ inputs.environment == 'CI' }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -136,14 +136,14 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ toJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ toJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Backup (Test folder)

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -55,10 +55,11 @@ jobs:
       fail-fast: false
       matrix:
         commands:
-          # - name: Arb1 FullList
-          #   path: [ArbTokenLists/arbed_full.json]
-          #   version: false
-          #   command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
+          - name: Arb1 FullList
+            path:
+              - ArbTokenLists/arbed_full.json
+            version: false
+            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
             paths:
@@ -67,49 +68,54 @@ jobs:
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
-          # - name: Arb1 Arbify Gemini
-          #   path: [ArbTokenLists/arbed_gemini_token_list.json]
-          #   version: true
-          #   command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
+          - name: Arb1 Arbify Gemini
+            path:
+              - ArbTokenLists/arbed_gemini_token_list.json
+            version: true
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
 
-          # - name: Arb1 Arbify CMC
-          #   path: [ArbTokenLists/arbed_coinmarketcap.json]
-          #   version: true
-          #   command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
+          - name: Arb1 Arbify CMC
+            path:
+              - ArbTokenLists/arbed_coinmarketcap.json
+            version: true
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
 
-          # - name: Arb1 Update Whitelist
-          #   path: [ArbTokenLists/arbed_arb_whitelist_era.json]
-          #   version: true
-          #   command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
+          - name: Arb1 Update Whitelist
+            path:
+              - ArbTokenLists/arbed_arb_whitelist_era.json
+            version: true
+            command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
-          # - name: ArbNova Arbify Uniswap
-          #   path: |
-          #     [
-          #       ArbTokenLists/42170_arbed_uniswap_labs.json
-          #       ArbTokenLists/42170_arbed_uniswap_labs_default.json
-          #     ]
-          #   version: true
-          #   command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+          - name: ArbNova Arbify Uniswap
+            path:
+              - ArbTokenLists/42170_arbed_uniswap_labs.json
+              - ArbTokenLists/42170_arbed_uniswap_labs_default.json
+            version: true
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
-          # - name: ArbNova Arbify Gemini
-          #   path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
-          #   version: true
-          #   command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
+          - name: ArbNova Arbify Gemini
+            path:
+              - ArbTokenLists/42170_arbed_gemini_token_list.json
+            version: true
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
 
-          # - name: ArbNova Arbify CMC
-          #   path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
-          #   version: true
-          #   command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
+          - name: ArbNova Arbify CMC
+            path:
+              - ArbTokenLists/42170_arbed_coinmarketcap.json
+            version: true
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
-          # - name: ArbGoerli Arbify CMC
-          #   path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
-          #   version: true
-          #   command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
+          - name: ArbGoerli Arbify CMC
+            path:
+              - ArbTokenLists/421613_arbed_coinmarketcap.json
+            version: true
+            command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
 
-          # - name: ArbGoerli FullList
-          #   path: [ArbTokenLists/421613_arbed_full.json]
-          #   version: false
-          #   command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
+          - name: ArbGoerli FullList
+            path:
+              - ArbTokenLists/421613_arbed_full.json
+            version: false
+            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'
@@ -158,9 +164,14 @@ jobs:
         if: ${{ inputs.environment == 'Test' }}
         run: aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }}/TestFolder --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json"
 
-      # - name: Backup
-      #   if: ${{ inputs.environment == 'CI' && matrix.commands.version == true }}
-      #   run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.paths[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
+      - name: Backup
+        if: ${{ inputs.environment == 'CI' && matrix.commands.version == true }}
+        run: |
+          paths=(${{ join(matrix.commands.paths, ' ') }})
+          for path in ${paths[*]}
+          do
+            aws s3 cp s3://${{ secrets.AWS_BUCKET }}/$path s3://${{ secrets.AWS_BUCKET }}/${{ steps.onlineVersion.outputs.onlineVersion }}/
+          done
 
       - name: Deploy
         if: ${{ inputs.environment == 'CI' }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -58,23 +58,23 @@ jobs:
           - name: Arb1 FullList
             command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
           - name: Arb1 Arbify Uniswap
-            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokens.uniswap.org --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
           - name: Arb1 Arbify Gemini
-            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://www.gemini.com/uniswap/manifest.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
           - name: Arb1 Arbify CMC
-            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
           - name: Arb1 Update Whitelist
             command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
           - name: ArbNova Arbify Gemini
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://www.gemini.com/uniswap/manifest.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
           - name: ArbNova Arbify CMC
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
-            command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
+            command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
           - name: ArbGoerli FullList
             command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,7 +141,7 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[2] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           if [[ -n $version ]]; then
             echo "onlineVersion=$version" >> $GITHUB_OUTPUT
           else
@@ -153,7 +153,7 @@ jobs:
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ matrix.commands.paths[2] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           if [[ -n $version ]]; then
             echo "newVersion=$version" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -126,13 +126,13 @@ jobs:
       - name: Get online version
         id: onlineVersion
         run: |
-          version=${curl s3://${{ secrets.AWS_BUCKET }}/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}'}
+          version=$(curl s3://${{ secrets.AWS_BUCKET }}/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
         id: newVersion
         run: |
-          version=${cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}'}
+          version=$(cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Display versions

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -56,8 +56,8 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
-            path: [ArbTokenLists/arbed_full]
-            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
+            path: [ArbTokenLists/arbed_full.json]
+            command: yarn fullList --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_full.json --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation
 
           - name: Arb1 Arbify Uniswap
             path:
@@ -101,7 +101,7 @@ jobs:
 
           - name: ArbGoerli FullList
             path: [ArbTokenLists/421613_arbed_full.json]
-            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
+            command: yarn fullList --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_full.json  --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'
@@ -135,10 +135,9 @@ jobs:
           version=$(cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
-      - name: Display versions
-        run: |
-          echo ${{ steps.newVersion.outputs.newVersion }}
-          echo ${{ steps.onlineVersion.outputs.onlineVersion }}
+      - name: Backup (Test folder)
+        if: ${{ inputs.environment == 'Test' }}
+        run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}
 
       - name: Deploy (Test folder)
         if: ${{ inputs.environment == 'Test' }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -59,7 +59,7 @@ jobs:
             paths:
               - ArbTokenLists/arbed_full.json
             version: false
-            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
+            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation
 
           - name: Arb1 Arbify Uniswap
             paths:
@@ -115,7 +115,7 @@ jobs:
             paths:
               - ArbTokenLists/421613_arbed_full.json
             version: false
-            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
+            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'
@@ -145,7 +145,7 @@ jobs:
           if [[ -n $version ]]; then
             echo "onlineVersion=$version" >> $GITHUB_OUTPUT
           else
-            # Make sure failure from curl, jq or awk fails the generation
+            # Make sure failure from curl or jq fails the generation
             exit 1
           fi
 
@@ -157,7 +157,7 @@ jobs:
           if [[ -n $version ]]; then
             echo "newVersion=$version" >> $GITHUB_OUTPUT
           else
-            # Make sure failure from curl, jq or awk fails the generation
+            # Make sure failure from curl or jq fails the generation
             exit 1
           fi
 

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -63,8 +63,8 @@ jobs:
           - name: Arb1 Arbify Uniswap
             path: |
               (
-                ArbTokenLists/arbed_uniswap_labs.json,
-                ArbTokenLists/arbed_uniswap_labs_default.json,
+                ArbTokenLists/arbed_uniswap_labs.json
+                ArbTokenLists/arbed_uniswap_labs_default.json
               )
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
@@ -87,8 +87,8 @@ jobs:
           - name: ArbNova Arbify Uniswap
             path: |
               (
-                ArbTokenLists/42170_arbed_uniswap_labs.json,
-                ArbTokenLists/42170_arbed_uniswap_labs_default.json,
+                ArbTokenLists/42170_arbed_uniswap_labs.json
+                ArbTokenLists/42170_arbed_uniswap_labs_default.json
               )
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -69,7 +69,7 @@ jobs:
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
           - name: Arb1 Arbify Gemini
-            path:
+            path: |
               - ArbTokenLists/arbed_gemini_token_list.json
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -61,7 +61,7 @@ jobs:
           #   command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
-            paths: |
+            paths:
               - ArbTokenLists/arbed_uniswap_labs.json
               - ArbTokenLists/arbed_uniswap_labs_default.json
             version: true

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,7 +141,8 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          # version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(exit 1)
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Get online version
         id: onlineVersion
         run: |
-          version=$(curl s3://${{ secrets.AWS_BUCKET }}/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
@@ -142,13 +142,11 @@ jobs:
 
       - name: Deploy (Test folder)
         if: ${{ inputs.environment == 'Test' }}
-        run: |
-
-          'aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }}/TestFolder --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json"'
+        run: aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }}/TestFolder --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json"
 
       - name: Deploy
         if: ${{ inputs.environment == 'CI' }}
-        run: 'aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }} --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json" --acl "public-read"'
+        run: aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }} --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json" --acl "public-read"
 
   error-alerts:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -62,9 +62,10 @@ jobs:
 
           - name: Arb1 Arbify Uniswap
             paths: |
-              {
-                \"paths\": [ArbTokenLists/arbed_uniswap_labs.json, ArbTokenLists/arbed_uniswap_labs_default.json]
-              }
+              (
+                ArbTokenLists/arbed_uniswap_labs.json
+                ArbTokenLists/arbed_uniswap_labs_default.json
+              )
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
@@ -136,20 +137,20 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ fromJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ fromJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ fromJson(matrix.commands.paths).paths }}
+          paths=${{ matrix.commands.path }}
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ join(matrix.commands.paths, ' ') }}
+          paths=(${{ join(matrix.commands.paths, ' ') }})
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,8 +141,7 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          # version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
-          version=$(exit 1)
+          version=$(curl https://tokenlist.arbitrum.io/ | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -56,26 +56,51 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
+            path: [ArbTokenLists/arbed_full]
             command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
+
           - name: Arb1 Arbify Uniswap
+            path:
+              [
+                ArbTokenLists/arbed_uniswap_labs.json,
+                ArbTokenLists/arbed_uniswap_labs_default.json,
+              ]
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
+
           - name: Arb1 Arbify Gemini
+            path: [ArbTokenLists/arbed_gemini_token_list.json]
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
+
           - name: Arb1 Arbify CMC
+            path: [ArbTokenLists/arbed_coinmarketcap.json]
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
+
           - name: Arb1 Update Whitelist
+            path: [ArbTokenLists/arbed_arb_whitelist_era.json]
             command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+            path:
+              [
+                ArbTokenLists/42170_arbed_uniswap_labs.json,
+                ArbTokenLists/42170_arbed_uniswap_labs_default.json,
+              ]
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+
           - name: ArbNova Arbify Gemini
+            path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
+
           - name: ArbNova Arbify CMC
+            path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
+            path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
             command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
+
           - name: ArbGoerli FullList
+            path: [ArbTokenLists/421613_arbed_full.json]
             command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
@@ -98,9 +123,28 @@ jobs:
         if: success()
         run: ${{ matrix.commands.command }}
 
+      - name: Get online version
+        id: onlineVersion
+        run: |
+          version=${curl s3://${{ secrets.AWS_BUCKET }}/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}'}
+          echo "onlineVersion=$version" >> $GITHUB_OUTPUT
+
+      - name: Get new version
+        id: newVersion
+        run: |
+          version=${cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}'}
+          echo "newVersion=$version" >> $GITHUB_OUTPUT
+
+      - name: Display versions
+        run: |
+          echo ${{ steps.newVersion.outputs.newVersion }}
+          echo ${{ steps.onlineVersion.outputs.onlineVersion }}
+
       - name: Deploy (Test folder)
         if: ${{ inputs.environment == 'Test' }}
-        run: 'aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }}/TestFolder --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json"'
+        run: |
+
+          'aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }}/TestFolder --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json"'
 
       - name: Deploy
         if: ${{ inputs.environment == 'CI' }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,7 +141,7 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[2] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           if [[ -n $version ]]; then
             echo "onlineVersion=$version" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=(${{ 'a' }})
+          paths=(${{ join(matrix.commands.paths, ' ') }})
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -141,7 +141,7 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version | jq 'join(".")'
           if [[ -n $version ]]; then
             echo "onlineVersion=$version" >> $GITHUB_OUTPUT
           else
@@ -153,7 +153,7 @@ jobs:
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ matrix.commands.paths[0] }} | jq .version | jq 'join(".")'
           if [[ -n $version ]]; then
             echo "newVersion=$version" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -57,7 +57,8 @@ jobs:
         commands:
           - name: Arb1 FullList
             path: [ArbTokenLists/arbed_full.json]
-            command: yarn fullList --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_full.json --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation
+            version: false
+            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
             path:
@@ -65,18 +66,22 @@ jobs:
                 ArbTokenLists/arbed_uniswap_labs.json,
                 ArbTokenLists/arbed_uniswap_labs_default.json,
               ]
+            version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
           - name: Arb1 Arbify Gemini
             path: [ArbTokenLists/arbed_gemini_token_list.json]
+            version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
 
           - name: Arb1 Arbify CMC
             path: [ArbTokenLists/arbed_coinmarketcap.json]
+            version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
 
           - name: Arb1 Update Whitelist
             path: [ArbTokenLists/arbed_arb_whitelist_era.json]
+            version: true
             command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
@@ -85,23 +90,28 @@ jobs:
                 ArbTokenLists/42170_arbed_uniswap_labs.json,
                 ArbTokenLists/42170_arbed_uniswap_labs_default.json,
               ]
+            version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
           - name: ArbNova Arbify Gemini
             path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
+            version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
 
           - name: ArbNova Arbify CMC
             path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
+            version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
             path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
+            version: true
             command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
 
           - name: ArbGoerli FullList
             path: [ArbTokenLists/421613_arbed_full.json]
-            command: yarn fullList --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_full.json  --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation
+            version: false
+            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'
@@ -125,18 +135,20 @@ jobs:
 
       - name: Get online version
         id: onlineVersion
+        if: ${{ matrix.commands.version == true }}
         run: |
           version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
         id: newVersion
+        if: ${{ matrix.commands.version == true }}
         run: |
           version=$(cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Backup (Test folder)
-        if: ${{ inputs.environment == 'Test' }}
+        if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
 
       - name: Deploy (Test folder)

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -56,27 +56,27 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
-            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation
+            command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
           - name: Arb1 Arbify Uniswap
-            command: yarn arbify --l2NetworkID 42161 --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokens.uniswap.org --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
           - name: Arb1 Arbify Gemini
-            command: yarn arbify --l2NetworkID 42161 --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://www.gemini.com/uniswap/manifest.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
           - name: Arb1 Arbify CMC
-            command: yarn arbify --l2NetworkID 42161 --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
           - name: Arb1 Update Whitelist
-            command: yarn update --l2NetworkID 42161 --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
+            command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
-            command: yarn arbify --l2NetworkID 42170 --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
           - name: ArbNova Arbify Gemini
-            command: yarn arbify --l2NetworkID 42170 --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://www.gemini.com/uniswap/manifest.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
           - name: ArbNova Arbify CMC
-            command: yarn arbify --l2NetworkID 42170 --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
-            command: yarn arbify --l2NetworkID 421613 --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
+            command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
           - name: ArbGoerli FullList
-            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation
+            command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:
       INFURA_KEY: '${{ secrets.INFURA_KEY }}'
       MAINNET_RPC: 'https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}'

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ matrix.commands.path }}
+          paths=(${{ join(matrix.commands.path, ', ') }})
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -61,9 +61,9 @@ jobs:
           #   command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
-            paths:
-              - ArbTokenLists/arbed_uniswap_labs.json
-              - ArbTokenLists/arbed_uniswap_labs_default.json
+            paths: |-
+              ArbTokenLists/arbed_uniswap_labs.json
+              ArbTokenLists/arbed_uniswap_labs_default.json
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
@@ -135,7 +135,7 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
@@ -148,7 +148,7 @@ jobs:
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ matrix.commands.path }}
+          paths=${{ matrix.commands.paths }}
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -56,60 +56,60 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
-            path: (ArbTokenLists/arbed_full.json)
+            path: [ArbTokenLists/arbed_full.json]
             version: false
             command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
             path: |
-              (
+              [
                 ArbTokenLists/arbed_uniswap_labs.json
                 ArbTokenLists/arbed_uniswap_labs_default.json
-              )
+              ]
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
           - name: Arb1 Arbify Gemini
-            path: (ArbTokenLists/arbed_gemini_token_list.json)
+            path: [ArbTokenLists/arbed_gemini_token_list.json]
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
 
           - name: Arb1 Arbify CMC
-            path: (ArbTokenLists/arbed_coinmarketcap.json)
+            path: [ArbTokenLists/arbed_coinmarketcap.json]
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
 
           - name: Arb1 Update Whitelist
-            path: (ArbTokenLists/arbed_arb_whitelist_era.json)
+            path: [ArbTokenLists/arbed_arb_whitelist_era.json]
             version: true
             command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
             path: |
-              (
+              [
                 ArbTokenLists/42170_arbed_uniswap_labs.json
                 ArbTokenLists/42170_arbed_uniswap_labs_default.json
-              )
+              ]
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
           - name: ArbNova Arbify Gemini
-            path: (ArbTokenLists/42170_arbed_gemini_token_list.json)
+            path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
 
           - name: ArbNova Arbify CMC
-            path: (ArbTokenLists/42170_arbed_coinmarketcap.json)
+            path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
-            path: (ArbTokenLists/421613_arbed_coinmarketcap.json)
+            path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
             version: true
             command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
 
           - name: ArbGoerli FullList
-            path: (ArbTokenLists/421613_arbed_full.json)
+            path: [ArbTokenLists/421613_arbed_full.json]
             version: false
             command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -56,60 +56,60 @@ jobs:
       matrix:
         commands:
           - name: Arb1 FullList
-            path: [ArbTokenLists/arbed_full.json]
+            path: (ArbTokenLists/arbed_full.json)
             version: false
             command: yarn fullList --l2NetworkID 42161 --newArbifiedList ./src/ArbTokenLists/arbed_full.json --skipValidation --ignorePreviousList
 
           - name: Arb1 Arbify Uniswap
-            path:
-              [
+            path: |
+              (
                 ArbTokenLists/arbed_uniswap_labs.json,
                 ArbTokenLists/arbed_uniswap_labs_default.json,
-              ]
+              )
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
           - name: Arb1 Arbify Gemini
-            path: [ArbTokenLists/arbed_gemini_token_list.json]
+            path: (ArbTokenLists/arbed_gemini_token_list.json)
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/arbed_gemini_token_list.json
 
           - name: Arb1 Arbify CMC
-            path: [ArbTokenLists/arbed_coinmarketcap.json]
+            path: (ArbTokenLists/arbed_coinmarketcap.json)
             version: true
             command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/arbed_coinmarketcap.json
 
           - name: Arb1 Update Whitelist
-            path: [ArbTokenLists/arbed_arb_whitelist_era.json]
+            path: (ArbTokenLists/arbed_arb_whitelist_era.json)
             version: true
             command: yarn update --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --tokenList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true --newArbifiedList ./src/ArbTokenLists/arbed_arb_whitelist_era.json
 
           - name: ArbNova Arbify Uniswap
-            path:
-              [
+            path: |
+              (
                 ArbTokenLists/42170_arbed_uniswap_labs.json,
                 ArbTokenLists/42170_arbed_uniswap_labs_default.json,
-              ]
+              )
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
           - name: ArbNova Arbify Gemini
-            path: [ArbTokenLists/42170_arbed_gemini_token_list.json]
+            path: (ArbTokenLists/42170_arbed_gemini_token_list.json)
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json  --tokenList https://www.gemini.com/uniswap/manifest.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_gemini_token_list.json
 
           - name: ArbNova Arbify CMC
-            path: [ArbTokenLists/42170_arbed_coinmarketcap.json]
+            path: (ArbTokenLists/42170_arbed_coinmarketcap.json)
             version: true
             command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_coinmarketcap.json
 
           - name: ArbGoerli Arbify CMC
-            path: [ArbTokenLists/421613_arbed_coinmarketcap.json]
+            path: (ArbTokenLists/421613_arbed_coinmarketcap.json)
             version: true
             command: yarn arbify --l2NetworkID 421613 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json --newArbifiedList ./src/ArbTokenLists/421613_arbed_coinmarketcap.json
 
           - name: ArbGoerli FullList
-            path: [ArbTokenLists/421613_arbed_full.json]
+            path: (ArbTokenLists/421613_arbed_full.json)
             version: false
             command: yarn fullList --l2NetworkID 421613 --newArbifiedList ./src/ArbTokenLists/421613_arbed_full.json --skipValidation --ignorePreviousList
     env:
@@ -135,25 +135,34 @@ jobs:
 
       - name: Get online version
         id: onlineVersion
-        if: ${{ matrix.commands.version == true }}
+        if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
           version=$(curl https://tokenlist.arbitrum.io/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
         id: newVersion
-        if: ${{ matrix.commands.version == true }}
+        if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
           version=$(cat ./src/${{ matrix.commands.path[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
-        run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
+        run: |
+          paths=${{ matrix.commands.path }}
+          for path in ${paths[*]}
+          do
+            aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
+          done
 
       - name: Deploy (Test folder)
         if: ${{ inputs.environment == 'Test' }}
         run: aws s3 sync ./src/ s3://${{ secrets.AWS_BUCKET }}/TestFolder --exclude "*" --include "FullList/*.json" --include "ArbTokenLists/*.json"
+
+      # - name: Backup
+      #   if: ${{ inputs.environment == 'CI' && matrix.commands.version == true }}
+      #   run: aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ matrix.commands.path[0] }} s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/
 
       - name: Deploy
         if: ${{ inputs.environment == 'CI' }}

--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -136,20 +136,20 @@ jobs:
         id: onlineVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true  }}
         run: |
-          version=$(curl https://tokenlist.arbitrum.io/${{ toJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(curl https://tokenlist.arbitrum.io/${{ fromJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "onlineVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Get new version
         id: newVersion
         if: ${{ matrix.commands.version == true && matrix.commands.version == true }}
         run: |
-          version=$(cat ./src/${{ toJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
+          version=$(cat ./src/${{ fromJson(matrix.commands.paths).paths[0] }} | jq .version[] | awk 'NR > 1 { printf(".") } {printf "%s",$0}')
           echo "newVersion=$version" >> $GITHUB_OUTPUT
 
       - name: Backup (Test folder)
         if: ${{ inputs.environment == 'Test' && matrix.commands.version == true }}
         run: |
-          paths=${{ toJson(matrix.commands.paths).paths }}
+          paths=${{ fromJson(matrix.commands.paths).paths }}
           for path in ${paths[*]}
           do
             aws s3 cp s3://${{ secrets.AWS_BUCKET }}/TestFolder/$path s3://${{ secrets.AWS_BUCKET }}/TestFolder/${{ steps.onlineVersion.outputs.onlineVersion }}/

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -61,7 +61,7 @@ const testNoDuplicates = (arbTokenList: ArbTokenList) => {
 };
 
 describe('Token Lists', () => {
-  jest.setTimeout(400_000);
+  jest.setTimeout(200_000);
 
   describe('Arbify token lists', () => {
     it('Arb1 Uniswap', async () => {
@@ -70,7 +70,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42161',
           '--tokenList=https://tokens.uniswap.org',
-          '--prevArbifiedList=https://tokens.uniswap.org',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json',
           '--newArbifiedList=./src/ArbTokenLists/arbed_uniswap_labs.json',
         ]),
         fetch(
@@ -88,7 +88,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42161',
           '--tokenList=https://www.gemini.com/uniswap/manifest.json',
-          '--prevArbifiedList=https://www.gemini.com/uniswap/manifest.json',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/arbed_gemini_token_list.json',
           '--newArbifiedList=./src/ArbTokenLists/arbed_gemini_token_list.json',
         ]),
         fetch(
@@ -106,7 +106,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42161',
           '--tokenList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
-          '--prevArbifiedList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/arbed_coinmarketcap.json',
           '--newArbifiedList=./src/ArbTokenLists/arbed_coinmarketcap.json',
         ]),
         fetch(
@@ -124,7 +124,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42170',
           '--tokenList=https://tokens.uniswap.org',
-          '--prevArbifiedList=https://tokens.uniswap.org',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs.json',
           '--newArbifiedList=./src/ArbTokenLists/42170_arbed_uniswap_labs.json',
         ]),
         fetch(
@@ -142,7 +142,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42170',
           '--tokenList=https://www.gemini.com/uniswap/manifest.json',
-          '--prevArbifiedList=https://www.gemini.com/uniswap/manifest.json',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_gemini_token_list.json',
           '--newArbifiedList=./src/ArbTokenLists/42170_arbed_gemini_token_list.json',
         ]),
         fetch(
@@ -160,7 +160,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42170',
           '--tokenList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
-          '--prevArbifiedList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_coinmarketcap.json',
           '--newArbifiedList=./src/ArbTokenLists/42170_arbed_coinmarketcap.json',
         ]),
         fetch(
@@ -178,7 +178,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=421613',
           '--tokenList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
-          '--prevArbifiedList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/421613_arbed_coinmarketcap.json',
           '--newArbifiedList=./src/ArbTokenLists/421613_arbed_coinmarketcap.json',
         ]),
         fetch(

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -100,7 +100,7 @@ describe('Token Lists', () => {
       compareLists(localList, onlineList);
     });
 
-    it.only('Arb1 CMC', async () => {
+    it('Arb1 CMC', async () => {
       expect.assertions(2);
       const [localList, onlineList] = await Promise.all([
         runCommand(Action.Arbify, [

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -61,7 +61,7 @@ const testNoDuplicates = (arbTokenList: ArbTokenList) => {
 };
 
 describe('Token Lists', () => {
-  jest.setTimeout(200_000);
+  jest.setTimeout(400_000);
 
   describe('Arbify token lists', () => {
     it('Arb1 Uniswap', async () => {

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -100,7 +100,7 @@ describe('Token Lists', () => {
       compareLists(localList, onlineList);
     });
 
-    it('Arb1 CMC', async () => {
+    it.only('Arb1 CMC', async () => {
       expect.assertions(2);
       const [localList, onlineList] = await Promise.all([
         runCommand(Action.Arbify, [

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -106,7 +106,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42161',
           '--tokenList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
           '--newArbifiedList=./src/ArbTokenLists/arbed_coinmarketcap.json',
         ]),
         fetch(

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -70,7 +70,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42161',
           '--tokenList=https://tokens.uniswap.org',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://tokens.uniswap.org',
           '--newArbifiedList=./src/ArbTokenLists/arbed_uniswap_labs.json',
         ]),
         fetch(
@@ -88,7 +88,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42161',
           '--tokenList=https://www.gemini.com/uniswap/manifest.json',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://www.gemini.com/uniswap/manifest.json',
           '--newArbifiedList=./src/ArbTokenLists/arbed_gemini_token_list.json',
         ]),
         fetch(
@@ -124,7 +124,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42170',
           '--tokenList=https://tokens.uniswap.org',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://tokens.uniswap.org',
           '--newArbifiedList=./src/ArbTokenLists/42170_arbed_uniswap_labs.json',
         ]),
         fetch(
@@ -142,7 +142,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42170',
           '--tokenList=https://www.gemini.com/uniswap/manifest.json',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://www.gemini.com/uniswap/manifest.json',
           '--newArbifiedList=./src/ArbTokenLists/42170_arbed_gemini_token_list.json',
         ]),
         fetch(
@@ -160,7 +160,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=42170',
           '--tokenList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
           '--newArbifiedList=./src/ArbTokenLists/42170_arbed_coinmarketcap.json',
         ]),
         fetch(
@@ -178,7 +178,7 @@ describe('Token Lists', () => {
         runCommand(Action.Arbify, [
           '--l2NetworkID=421613',
           '--tokenList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
-          '--ignorePreviousList=true',
+          '--prevArbifiedList=https://api.coinmarketcap.com/data-api/v3/uniswap/all.json',
           '--newArbifiedList=./src/ArbTokenLists/421613_arbed_coinmarketcap.json',
         ]),
         fetch(
@@ -199,6 +199,7 @@ describe('Token Lists', () => {
           '--l2NetworkID=42161',
           '--tokenList=https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json',
           '--includeOldDataFields=true',
+          '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/arbed_arb_whitelist_era.json',
           '--newArbifiedList=./src/ArbTokenLists/arbed_arb_whitelist_era.json',
         ]),
         fetch(

--- a/__test__/unit/getVersion.test.ts
+++ b/__test__/unit/getVersion.test.ts
@@ -1,0 +1,121 @@
+import { getVersion } from '../../src/lib/getVersion';
+import {
+  baseList,
+  majorList,
+  minorList,
+  patchList,
+  withoutExtensions,
+} from './getVersionMockup';
+
+describe('getVersion', () => {
+  it('Should return 1.0.0 version if no previous list is passed', () => {
+    const version = getVersion(null, baseList().tokens);
+    expect(version).toStrictEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+    });
+
+    const versionWithoutExtensions = getVersion(
+      null,
+      withoutExtensions(baseList().tokens),
+    );
+    expect(versionWithoutExtensions).toStrictEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+    });
+  });
+
+  it('Should not bump version if lists are equal', () => {
+    const version = getVersion(baseList(), baseList().tokens);
+    expect(version).toStrictEqual({
+      major: 2,
+      minor: 3,
+      patch: 4,
+    });
+
+    const prevList = baseList();
+    const versionWithoutExtensions = getVersion(
+      {
+        ...prevList,
+        tokens: withoutExtensions(prevList.tokens),
+      },
+      withoutExtensions(baseList().tokens),
+    );
+    expect(versionWithoutExtensions).toStrictEqual({
+      major: 2,
+      minor: 3,
+      patch: 4,
+    });
+  });
+
+  it('Should bump patch version if extensions are different', () => {
+    const [prevList, newList] = patchList();
+    const version = getVersion(prevList, newList);
+    expect(version).toStrictEqual({
+      major: 2,
+      minor: 3,
+      patch: 5,
+    });
+
+    const versionWithoutExtensions = getVersion(
+      {
+        ...prevList,
+        tokens: withoutExtensions(prevList.tokens),
+      },
+      withoutExtensions(newList),
+    );
+    expect(versionWithoutExtensions).toStrictEqual({
+      major: 2,
+      minor: 3,
+      patch: 4,
+    });
+  });
+
+  it('Should bump minor version if extensions are added', () => {
+    const [prevList, newList] = minorList();
+    const version = getVersion(prevList, newList);
+    expect(version).toStrictEqual({
+      major: 2,
+      minor: 4,
+      patch: 0,
+    });
+
+    const versionWithoutExtensions = getVersion(
+      {
+        ...prevList,
+        tokens: withoutExtensions(prevList.tokens),
+      },
+      withoutExtensions(newList),
+    );
+    expect(versionWithoutExtensions).toStrictEqual({
+      major: 2,
+      minor: 3,
+      patch: 4,
+    });
+  });
+
+  it('Should bump major version if extensions are removed', () => {
+    const [prevList, newList] = majorList();
+    const version = getVersion(prevList, newList);
+    expect(version).toStrictEqual({
+      major: 3,
+      minor: 0,
+      patch: 0,
+    });
+
+    const versionWithoutExtensions = getVersion(
+      {
+        ...prevList,
+        tokens: withoutExtensions(prevList.tokens),
+      },
+      withoutExtensions(newList),
+    );
+    expect(versionWithoutExtensions).toStrictEqual({
+      major: 2,
+      minor: 3,
+      patch: 4,
+    });
+  });
+});

--- a/__test__/unit/getVersionMockup.ts
+++ b/__test__/unit/getVersionMockup.ts
@@ -1,0 +1,116 @@
+import { ArbTokenInfo, ArbTokenList } from '../../src/lib/types';
+
+const common = {
+  name: 'Arbed Uniswap',
+  timestamp: '2023-01-17T13:21:35.005Z',
+  version: {
+    major: 2,
+    minor: 3,
+    patch: 4,
+  },
+};
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+type Mock = ArbTokenList & {
+  tokens: Mutable<ArbTokenList['tokens']>;
+};
+export function baseList(): Mock {
+  return {
+    ...common,
+    tokens: [
+      {
+        chainId: 42161,
+        address: '0x6314C31A7a1652cE482cffe247E9CB7c3f4BB9aF',
+        name: '1INCH Token',
+        symbol: '1INCH',
+        decimals: 18,
+        logoURI:
+          'https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028',
+        extensions: {
+          bridgeInfo: {
+            '1': {
+              tokenAddress: '0x111111111117dc0aa78b770fa6a738034120c302',
+              originBridgeAddress: '0x09e9222E96E7B4AE2a407B98d48e330053351EEe',
+              destBridgeAddress: '0xa3a7b6f88361f48403514059f1f16c8e78d60eec',
+            },
+          },
+        },
+      },
+      {
+        chainId: 42161,
+        address: '0xba5DdD1f9d7F570dc94a51479a000E3BCE967196',
+        name: 'Aave Token',
+        symbol: 'AAVE',
+        decimals: 18,
+        logoURI:
+          'https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110',
+        extensions: {
+          bridgeInfo: {
+            '1': {
+              tokenAddress: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+              originBridgeAddress: '0x09e9222E96E7B4AE2a407B98d48e330053351EEe',
+              destBridgeAddress: '0xa3a7b6f88361f48403514059f1f16c8e78d60eec',
+            },
+          },
+        },
+      },
+      {
+        chainId: 42161,
+        address: '0xeC76E8fe6e2242e6c2117caA244B9e2DE1569923',
+        name: 'AIOZ Network',
+        symbol: 'AIOZ',
+        decimals: 18,
+        logoURI:
+          'https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126',
+        extensions: {
+          bridgeInfo: {
+            '1': {
+              tokenAddress: '0x626e8036deb333b408be468f951bdb42433cbf18',
+              originBridgeAddress: '0x09e9222E96E7B4AE2a407B98d48e330053351EEe',
+              destBridgeAddress: '0xa3a7b6f88361f48403514059f1f16c8e78d60eec',
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+export function withoutExtensions(tokens: ArbTokenInfo[]) {
+  tokens.forEach((token) => {
+    delete token.extensions;
+  });
+
+  return tokens;
+}
+
+export function patchList() {
+  const prevList = baseList();
+  const newList = baseList();
+
+  newList.tokens[0].extensions!.bridgeInfo[1].tokenAddress =
+    'different token address';
+  return [prevList, newList.tokens] as const;
+}
+
+export function minorList() {
+  const prevList = baseList();
+  const newList = baseList();
+
+  delete prevList.tokens[2].extensions;
+  newList.tokens[1].extensions!.bridgeInfo[1].tokenAddress =
+    'different token address';
+
+  // PrevList: [tokenWithExtension, tokenWithExtension, tokenWithoutExtension]
+  // NewList: [tokenWithExtension, tokenWithUpdatedExtension, tokenWithExtension]
+  return [prevList, newList.tokens] as const;
+}
+
+export function majorList() {
+  const [prevList, newListTokens] = minorList();
+
+  delete newListTokens[0].extensions;
+  // PrevList: [tokenWithExtension, tokenWithExtension, tokenWithoutExtension]
+  // NewList: [tokenWithoutExtension, tokenWithUpdatedExtension, tokenWithExtension]
+  return [prevList, newListTokens] as const;
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "update": "yarn ts-node src/main.ts update",
     "arbify": "yarn ts-node src/main.ts arbify",
     "permit": "yarn ts-node src/main.ts permit",
-    "fullList": "yarn ts-node src/main.ts full --tokenList full",
+    "fullList": "yarn ts-node src/main.ts full --tokenList full --ignorePreviousList",
     "allTokensList": "yarn ts-node src/main.ts alltokenslist --tokenList full",
     "updateNova": "yarn ts-node src/main.ts update --l2NetworkID 42170",
     "novaify": "yarn ts-node src/main.ts arbify --l2NetworkID 42170",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "updateNova": "yarn ts-node src/main.ts update --l2NetworkID 42170",
     "novaify": "yarn ts-node src/main.ts arbify --l2NetworkID 42170",
     "fullNova": "yarn ts-node src/main.ts full --tokenList full --l2NetworkID 42170",
-    "test": "jest --runInBand --silent",
+    "test": "jest --runInBand",
     "test:integration": "yarn test --ci __test__/integration",
     "test:unit": "yarn test --ci __test__/unit"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "updateNova": "yarn ts-node src/main.ts update --l2NetworkID 42170",
     "novaify": "yarn ts-node src/main.ts arbify --l2NetworkID 42170",
     "fullNova": "yarn ts-node src/main.ts full --tokenList full --l2NetworkID 42170",
-    "test": "jest --runInBand",
+    "test": "jest --runInBand --silent",
     "test:integration": "yarn test --ci __test__/integration",
     "test:unit": "yarn test --ci __test__/unit"
   },

--- a/src/lib/getVersion.ts
+++ b/src/lib/getVersion.ts
@@ -1,0 +1,86 @@
+import {
+  VersionUpgrade,
+  diffTokenLists,
+  minVersionBump,
+  nextVersion,
+} from '@uniswap/token-lists';
+import { ArbTokenInfo, ArbTokenList } from './types';
+import { isDeepStrictEqual } from 'util';
+
+function createTokensMap(tokens: ArbTokenInfo[]) {
+  return tokens
+    .filter((token) => token.extensions)
+    .reduce((acc, value) => {
+      acc.set(value.address, value.extensions);
+      return acc;
+    }, new Map());
+}
+
+function getVersion(
+  prevArbTokenList: ArbTokenList | null | undefined,
+  arbifiedTokenList: ArbTokenInfo[],
+) {
+  if (!prevArbTokenList) {
+    return {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    };
+  }
+
+  let versionBump = minVersionBump(prevArbTokenList.tokens, arbifiedTokenList);
+  const diff = diffTokenLists(prevArbTokenList.tokens, arbifiedTokenList);
+
+  // Uniswap report changes if a token has extensions property
+  const changedDiffKeys = Object.keys(diff.changed);
+  const isOnlyExtensionsDiff =
+    changedDiffKeys.length > 0 &&
+    changedDiffKeys.every((chainId) => {
+      return Object.values(diff.changed[Number(chainId)]).every((change) =>
+        isDeepStrictEqual(change, ['extensions']),
+      );
+    });
+
+  if (!isOnlyExtensionsDiff || versionBump !== VersionUpgrade.PATCH) {
+    return nextVersion(prevArbTokenList.version, versionBump);
+  }
+
+  const prevTokens = createTokensMap(prevArbTokenList.tokens);
+  const newTokens = createTokensMap(arbifiedTokenList);
+
+  if (newTokens.size > prevTokens.size) {
+    return nextVersion(prevArbTokenList.version, VersionUpgrade.MINOR);
+  }
+
+  if (newTokens.size < prevTokens.size) {
+    return nextVersion(prevArbTokenList.version, VersionUpgrade.MAJOR);
+  }
+
+  versionBump = VersionUpgrade.NONE;
+  for (const [key] of prevTokens) {
+    const prevExtension = prevTokens.get(key);
+    const newExtensions = newTokens.get(key);
+
+    // Extensions were removed, bump to major
+    if (prevExtension && !newExtensions) {
+      return nextVersion(prevArbTokenList.version, VersionUpgrade.MAJOR);
+    }
+
+    // Extensions were added, bump to minor.
+    if (!prevExtension && newExtensions) {
+      versionBump = VersionUpgrade.MINOR;
+    }
+
+    if (!isDeepStrictEqual(prevExtension, newExtensions)) {
+      // If versionBump was changed to MINOR, don't change it
+      versionBump =
+        versionBump === VersionUpgrade.MINOR
+          ? versionBump
+          : VersionUpgrade.PATCH;
+    }
+  }
+
+  return nextVersion(prevArbTokenList.version, versionBump);
+}
+
+export { getVersion };

--- a/src/lib/getVersion.ts
+++ b/src/lib/getVersion.ts
@@ -28,10 +28,9 @@ function getVersion(
     };
   }
 
-  console.time('getVersion');
   let versionBump = minVersionBump(prevArbTokenList.tokens, arbifiedTokenList);
   const diff = diffTokenLists(prevArbTokenList.tokens, arbifiedTokenList);
-  console.timeLog('getVersion', 'after diff');
+
   // Uniswap report changes if a token has extensions property
   const changedDiffKeys = Object.keys(diff.changed);
   const isOnlyExtensionsDiff =
@@ -41,14 +40,14 @@ function getVersion(
         isDeepStrictEqual(change, ['extensions']),
       );
     });
-  console.timeLog('getVersion', 'after isOnlyExtensionsDiff');
+
   if (!isOnlyExtensionsDiff || versionBump !== VersionUpgrade.PATCH) {
     return nextVersion(prevArbTokenList.version, versionBump);
   }
 
   const prevTokens = createTokensMap(prevArbTokenList.tokens);
   const newTokens = createTokensMap(arbifiedTokenList);
-  console.timeLog('getVersion', 'after createMap');
+
   if (newTokens.size > prevTokens.size) {
     return nextVersion(prevArbTokenList.version, VersionUpgrade.MINOR);
   }
@@ -58,7 +57,6 @@ function getVersion(
   }
 
   versionBump = VersionUpgrade.NONE;
-  console.timeLog('getVersion', 'before forLoop');
   for (const [key] of prevTokens) {
     const prevExtension = prevTokens.get(key);
     const newExtensions = newTokens.get(key);
@@ -81,7 +79,7 @@ function getVersion(
           : VersionUpgrade.PATCH;
     }
   }
-  console.timeLog('getVersion', 'after loop');
+
   return nextVersion(prevArbTokenList.version, versionBump);
 }
 

--- a/src/lib/getVersion.ts
+++ b/src/lib/getVersion.ts
@@ -28,9 +28,10 @@ function getVersion(
     };
   }
 
+  console.time('getVersion');
   let versionBump = minVersionBump(prevArbTokenList.tokens, arbifiedTokenList);
   const diff = diffTokenLists(prevArbTokenList.tokens, arbifiedTokenList);
-
+  console.timeLog('getVersion', 'after diff');
   // Uniswap report changes if a token has extensions property
   const changedDiffKeys = Object.keys(diff.changed);
   const isOnlyExtensionsDiff =
@@ -40,14 +41,14 @@ function getVersion(
         isDeepStrictEqual(change, ['extensions']),
       );
     });
-
+  console.timeLog('getVersion', 'after isOnlyExtensionsDiff');
   if (!isOnlyExtensionsDiff || versionBump !== VersionUpgrade.PATCH) {
     return nextVersion(prevArbTokenList.version, versionBump);
   }
 
   const prevTokens = createTokensMap(prevArbTokenList.tokens);
   const newTokens = createTokensMap(arbifiedTokenList);
-
+  console.timeLog('getVersion', 'after createMap');
   if (newTokens.size > prevTokens.size) {
     return nextVersion(prevArbTokenList.version, VersionUpgrade.MINOR);
   }
@@ -57,6 +58,7 @@ function getVersion(
   }
 
   versionBump = VersionUpgrade.NONE;
+  console.timeLog('getVersion', 'before forLoop');
   for (const [key] of prevTokens) {
     const prevExtension = prevTokens.get(key);
     const newExtensions = newTokens.get(key);
@@ -79,7 +81,7 @@ function getVersion(
           : VersionUpgrade.PATCH;
     }
   }
-
+  console.timeLog('getVersion', 'after loop');
   return nextVersion(prevArbTokenList.version, versionBump);
 }
 

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -52,13 +52,25 @@ const options = {
     type: 'boolean',
     default: false,
   },
+  // This is required, but setting required here would disallow setting it to false when `ignorePreviousList` is true
   prevArbifiedList: {
     type: 'string',
-    demandOption: true,
   },
 } as const;
 
-const yargsInstance = yargs(hideBin(process.argv)).options(options);
+const yargsInstance = yargs(hideBin(process.argv))
+  .options(options)
+  .check(({ ignorePreviousList, prevArbifiedList }) => {
+    if (ignorePreviousList && !prevArbifiedList) {
+      return true;
+    }
+
+    if (prevArbifiedList && !ignorePreviousList) {
+      return true;
+    }
+
+    return false;
+  });
 
 type Args = Arguments<InferredOptionTypes<typeof options>>;
 

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -54,7 +54,7 @@ const options = {
   },
   prevArbifiedList: {
     type: 'string',
-    default: null,
+    demandOption: true,
   },
 } as const;
 

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -65,7 +65,7 @@ const yargsInstance = yargs(hideBin(process.argv))
       return true;
     }
 
-    if (prevArbifiedList && !ignorePreviousList) {
+    if (!ignorePreviousList && prevArbifiedList) {
       return true;
     }
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,11 +1,30 @@
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
+import axios from 'axios';
+
 import { ArbTokenList, EtherscanList } from './types';
 import { isArbTokenList } from './utils';
 
-export const getPrevList = (
+const isValidUrl = (url: string) => {
+  try {
+    return Boolean(new URL(url));
+  } catch (e) {
+    return false;
+  }
+};
+
+export const getPrevList = async (
   arbifiedList: string | null,
-): ArbTokenList | undefined => {
+): Promise<ArbTokenList | undefined> => {
   const path = arbifiedList ?? '';
+  // If the path is an URL to a list
+  if (isValidUrl(path)) {
+    const list = await axios.get(path).then((response) => response.data);
+    console.log('Prev version of Arb List found');
+
+    isArbTokenList(list);
+    return list as ArbTokenList;
+  }
+
   if (!existsSync(path)) {
     console.log("Doesn't exist an arbified list.");
     return undefined;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -13,7 +13,7 @@ const isValidUrl = (url: string) => {
 };
 
 export const getPrevList = async (
-  arbifiedList: string | null,
+  arbifiedList: string | undefined,
 ): Promise<ArbTokenList | undefined> => {
   const path = arbifiedList ?? '';
   // If the path is an URL to a list

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -321,11 +321,6 @@ export const generateTokenList = async (
   }
 
   const version = getVersion(prevArbTokenList, arbifiedTokenList);
-  // const version = {
-  //   major: 1,
-  //   minor: 0,
-  //   patch: 0,
-  // };
 
   const sourceListURL = getFormattedSourceURL(options?.sourceListURL);
   const arbTokenList: ArbTokenList = {

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -320,12 +320,12 @@ export const generateTokenList = async (
     arbifiedTokenList = arbifiedTokenList.concat(unbridgedTokens);
   }
 
-  // const version = getVersion(prevArbTokenList, arbifiedTokenList);
-  const version = {
-    major: 1,
-    minor: 0,
-    patch: 0,
-  };
+  const version = getVersion(prevArbTokenList, arbifiedTokenList);
+  // const version = {
+  //   major: 1,
+  //   minor: 0,
+  //   patch: 0,
+  // };
 
   const sourceListURL = getFormattedSourceURL(options?.sourceListURL);
   const arbTokenList: ArbTokenList = {

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -352,6 +352,7 @@ export const generateTokenList = async (
       prevArbTokenList.tokens.map(removeExtensions);
     const arbifiedTokenListWithoutExtensions =
       arbifiedTokenList.map(removeExtensions);
+
     const versionBump = minVersionBump(
       listsWithoutExtensions,
       arbifiedTokenListWithoutExtensions,
@@ -405,7 +406,7 @@ export const arbifyL1List = async (
   }: {
     includeOldDataFields: boolean;
     ignorePreviousList: boolean;
-    prevArbifiedList: string | null;
+    prevArbifiedList: string | undefined;
   },
 ): Promise<{
   newList: ArbTokenList;
@@ -446,7 +447,7 @@ export const updateArbifiedList = async (
   }: {
     includeOldDataFields: boolean;
     ignorePreviousList: boolean;
-    prevArbifiedList: string | null;
+    prevArbifiedList: string | undefined;
   },
 ) => {
   const arbTokenList = await getTokenListObj(pathOrUrl);

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -1,4 +1,4 @@
-import { minVersionBump, nextVersion, TokenList } from '@uniswap/token-lists';
+import { TokenList } from '@uniswap/token-lists';
 import { getAllTokens } from './graph';
 import { constants, utils } from 'ethers';
 
@@ -33,6 +33,7 @@ import { getNetworkConfig } from './instantiate_bridge';
 import { getPrevList } from './store';
 import { getArgvs } from './options';
 import { BridgedUSDCContractAddressArb1 } from './constants';
+import { getVersion } from './getVersion';
 
 export interface ArbificationOptions {
   overwriteCurrentList: boolean;
@@ -319,47 +320,7 @@ export const generateTokenList = async (
     arbifiedTokenList = arbifiedTokenList.concat(unbridgedTokens);
   }
 
-  const version = (() => {
-    if (!prevArbTokenList) {
-      return {
-        major: 1,
-        minor: 0,
-        patch: 0,
-      };
-    }
-
-    const removeExtensions = ({
-      symbol,
-      name,
-      decimals,
-      chainId,
-      address,
-      logoURI,
-      tags,
-    }: ArbTokenInfo) => {
-      return {
-        symbol,
-        name,
-        decimals,
-        chainId,
-        address,
-        logoURI,
-        tags,
-      };
-    };
-    // Uniswap consider extensions to be patch even if nothing changed
-    const listsWithoutExtensions =
-      prevArbTokenList.tokens.map(removeExtensions);
-    const arbifiedTokenListWithoutExtensions =
-      arbifiedTokenList.map(removeExtensions);
-
-    const versionBump = minVersionBump(
-      listsWithoutExtensions,
-      arbifiedTokenListWithoutExtensions,
-    );
-
-    return nextVersion(prevArbTokenList.version, versionBump);
-  })();
+  const version = getVersion(prevArbTokenList, arbifiedTokenList);
 
   const sourceListURL = getFormattedSourceURL(options?.sourceListURL);
   const arbTokenList: ArbTokenList = {

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -320,7 +320,12 @@ export const generateTokenList = async (
     arbifiedTokenList = arbifiedTokenList.concat(unbridgedTokens);
   }
 
-  const version = getVersion(prevArbTokenList, arbifiedTokenList);
+  // const version = getVersion(prevArbTokenList, arbifiedTokenList);
+  const version = {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  };
 
   const sourceListURL = getFormattedSourceURL(options?.sourceListURL);
   const arbTokenList: ArbTokenList = {

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -17,7 +17,6 @@ import {
   sanitizeSymbolString,
   isNetwork,
   listNameToArbifiedListName,
-  isArbTokenList,
   removeInvalidTokensFromList,
   isValidHttpUrl,
   getFormattedSourceURL,
@@ -28,7 +27,6 @@ import {
 } from './utils';
 import { validateTokenListWithErrorThrowing } from './validateTokenList';
 import { constants as arbConstants } from '@arbitrum/sdk';
-import { readFileSync, existsSync } from 'fs';
 import { getNetworkConfig } from './instantiate_bridge';
 import { getPrevList } from './store';
 import { getArgvs } from './options';
@@ -383,10 +381,6 @@ export const arbifyL1List = async (
     ? null
     : await getPrevList(prevArbifiedList);
 
-  if (!ignorePreviousList && !prevArbTokenList) {
-    throw new Error('prevArbifiedList wasn`t found.');
-  }
-
   const newList = await generateTokenList(l1TokenList, prevArbTokenList, {
     includeAllL1Tokens: true,
     includeOldDataFields,
@@ -413,18 +407,9 @@ export const updateArbifiedList = async (
 ) => {
   const arbTokenList = await getTokenListObj(pathOrUrl);
   removeInvalidTokensFromList(arbTokenList);
-  const oldPath = prevArbifiedList ?? '';
-  let prevArbTokenList: ArbTokenList | undefined;
-
-  if (existsSync(oldPath)) {
-    const data = readFileSync(oldPath);
-    console.log('Prev version of Arb List found');
-
-    if (!ignorePreviousList) {
-      prevArbTokenList = JSON.parse(data.toString()) as ArbTokenList;
-      isArbTokenList(prevArbTokenList);
-    }
-  }
+  const prevArbTokenList = ignorePreviousList
+    ? null
+    : await getPrevList(prevArbifiedList);
 
   const newList = await generateTokenList(arbTokenList, prevArbTokenList, {
     includeAllL1Tokens: true,


### PR DESCRIPTION
- [X] Pass prevArbTokenList during generation.
- [X] Update prevArbTokenList to be required. 
- [X] Fix patch version (see https://github.com/OffchainLabs/arbitrum-token-lists/blob/master/src/lib/token_list_gen.ts#L334)
- [X] Add integration tests for versioning
- [X] Backup previous versions