### PR TITLE
chore: update @uniswap/token-lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@arbitrum/sdk": "^3.0.0",
     "@types/jest": "^29.2.5",
-    "@uniswap/token-lists": "^1.0.0-beta.31",
+    "@uniswap/token-lists": "^1.0.0-beta.33",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "axios": "^0.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,10 +1229,10 @@
     "@typescript-eslint/types" "5.50.0"
     eslint-visitor-keys "^3.3.0"
 
-"@uniswap/token-lists@^1.0.0-beta.31":
-  version "1.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.31.tgz#ff3852bd505ec7b4c276625c762ea79a93a919ec"
-  integrity sha512-BQVoelKCRf64IToPEs1wxiXOnhr/ukwPOF78XG11PrTAOL4F8umjYKFb8ZPv1/dIJsPaC7GhLSriEqyp94SasQ==
+"@uniswap/token-lists@^1.0.0-beta.33":
+  version "1.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz#966ba96c9ccc8f0e9e09809890b438203f2b1911"
+  integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
Uniswap list now includes `tokenMap` property, we need to bump `@uniswap-token-lists` package to have proper types during validations

see https://github.com/Uniswap/token-lists/pull/421