### PR TITLE
fix: Update uniswap token list URL

### DIFF
--- a/.github/workflows/generate-token-lists.yml
+++ b/.github/workflows/generate-token-lists.yml
@@ -67,7 +67,7 @@ jobs:
               - ArbTokenLists/arbed_uniswap_labs.json
               - ArbTokenLists/arbed_uniswap_labs_default.json
             version: true
-            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://gateway.ipfs.io/ipns/tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
+            command: yarn arbify --l2NetworkID 42161 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json && cp ./src/ArbTokenLists/arbed_uniswap_labs.json ./src/ArbTokenLists/arbed_uniswap_labs_default.json
 
           - name: Arb1 Arbify Gemini
             paths:
@@ -99,7 +99,7 @@ jobs:
               - ArbTokenLists/42170_arbed_uniswap_labs.json
               - ArbTokenLists/42170_arbed_uniswap_labs_default.json
             version: true
-            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://gateway.ipfs.io/ipns/tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
+            command: yarn arbify --l2NetworkID 42170 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs_default.json --newArbifiedList ./src/ArbTokenLists/42170_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org && cp ./src/ArbTokenLists/42170_arbed_uniswap_labs.json ./src/ArbTokenLists/42170_arbed_uniswap_labs_default.json
 
           - name: ArbNova Arbify Gemini
             paths:
@@ -143,7 +143,7 @@ jobs:
             paths:
               - ArbTokenLists/421614_arbed_uniswap_labs.json
             version: true
-            command: yarn arbify --l2NetworkID 421614 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421614_arbed_uniswap_labs.json --tokenList https://gateway.ipfs.io/ipns/tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/421614_arbed_uniswap_labs.json
+            command: yarn arbify --l2NetworkID 421614 --prevArbifiedList https://tokenlist.arbitrum.io/ArbTokenLists/421614_arbed_uniswap_labs.json --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/421614_arbed_uniswap_labs.json
 
           - name: ArbSepolia Arbify CoinGecko
             paths:

--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -70,7 +70,7 @@ describe('Token Lists', () => {
         const [localList, onlineList] = await Promise.all([
           runCommand(Action.Arbify, [
             '--l2NetworkID=42161',
-            '--tokenList=https://gateway.ipfs.io/ipns/tokens.uniswap.org',
+            '--tokenList=https://tokens.uniswap.org',
             '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs.json',
             '--newArbifiedList=./src/ArbTokenLists/arbed_uniswap_labs.json',
           ]),
@@ -144,7 +144,7 @@ describe('Token Lists', () => {
         const [localList, onlineList] = await Promise.all([
           runCommand(Action.Arbify, [
             '--l2NetworkID=42170',
-            '--tokenList=https://gateway.ipfs.io/ipns/tokens.uniswap.org',
+            '--tokenList=https://tokens.uniswap.org',
             '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/42170_arbed_uniswap_labs.json',
             '--newArbifiedList=./src/ArbTokenLists/42170_arbed_uniswap_labs.json',
           ]),
@@ -256,7 +256,7 @@ describe('Token Lists', () => {
         const [localList, onlineList] = await Promise.all([
           runCommand(Action.Arbify, [
             '--l2NetworkID=421614',
-            '--tokenList=https://gateway.ipfs.io/ipns/tokens.uniswap.org',
+            '--tokenList=https://tokens.uniswap.org',
             '--prevArbifiedList=https://tokenlist.arbitrum.io/ArbTokenLists/421614_arbed_uniswap_labs.json',
             '--newArbifiedList=./src/ArbTokenLists/421614_arbed_uniswap_labs.json',
           ]),


### PR DESCRIPTION
Reverting https://github.com/OffchainLabs/arbitrum-token-lists/pull/111

tokens.uniswap.org is a valid URL, but for some reason, it was blocked in some countries. It should be fine in the context of github actions