### PR TITLE
fix: don't escape usdt name

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -396,10 +396,10 @@ export const isTokenList = (obj: any) => {
 };
 
 export const sanitizeNameString = (str: string) =>
-  str.replace(/[^ \w.'+\-%/À-ÖØ-öø-ÿ:&\[\]\(\)]/gi, '');
+  str.replace(/[^ \w.'+\-%/À-ÖØ-öø-ÿ:&\[\]\(\)₮]/gi, '');
 
 export const sanitizeSymbolString = (str: string) =>
-  str.replace(/[^\w.'+\-%/À-ÖØ-öø-ÿ:&\[\]\(\)]/gi, '');
+  str.replace(/[^\w.'+\-%/À-ÖØ-öø-ÿ:&\[\]\(\)₮]/gi, '');
 
 export function* getChunks<T>(arr: Array<T>, chunkSize = 500) {
   for (let i = 0; i < arr.length; i += chunkSize) {


### PR DESCRIPTION
`yarn arbify --l2NetworkID 42161 --ignore-previous-list --tokenList https://tokens.uniswap.org --newArbifiedList ./src/ArbTokenLists/arbed_uniswap_labs.json` returns the non-escaped USDT name and symbol:
```
{
  "chainId": 42161,
  "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
  "name": "USD₮0",
  "symbol": "USD₮0",
  ...
},
```