### PR TITLE
fix: Disable rari testnet

### DIFF
--- a/src/customNetworks.ts
+++ b/src/customNetworks.ts
@@ -1,7 +1,8 @@
 import { ArbitrumNetwork } from '@arbitrum/sdk';
 import orbitChainsData from './Assets/orbitChainsData.json';
 
-const excludedNetworksIds: number[] = [];
+const excludedNetworksIds: number[] = [1918988905]; // RARI testnet
+
 export const customNetworks = (
   orbitChainsData.data as ArbitrumNetwork[]
 ).filter((chain) => !excludedNetworksIds.includes(chain.chainId));


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
