### PR TITLE
chore: Remove wylerchain sepolia from excluded networks

### DIFF
--- a/src/customNetworks.ts
+++ b/src/customNetworks.ts
@@ -1,7 +1,7 @@
 import { ArbitrumNetwork } from '@arbitrum/sdk';
 import orbitChainsData from './Assets/orbitChainsData.json';
 
-const excludedNetworksIds: number[] = [98867, 1712]; // Plume testnet, Wylerchain Sepolia
+const excludedNetworksIds: number[] = [98867]; // Plume testnet
 
 export const customNetworks = (
   orbitChainsData.data as ArbitrumNetwork[]


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
