### PR TITLE
feat: Add Wrapped 0xForce (wXFO) L2 native token

### DIFF
--- a/src/Assets/42161_arbitrum_native_token_list.json
+++ b/src/Assets/42161_arbitrum_native_token_list.json
@@ -30,6 +30,14 @@
       "symbol": "rsETH",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/33800/large/Icon___Dark.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x25cf13fe02af9181cb5361bac4610e5c2e8b2519",
+      "name": "Wrapped 0xForce",
+      "symbol": "wXFO",
+      "decimals": 18,
+      "logoURI": "https://xfo.network/images/logo/xfo_token_logo.png"
     }
   ],
   "logoURI": "https://avatars.githubusercontent.com/u/43838009"

--- a/src/Assets/logo_uris.json
+++ b/src/Assets/logo_uris.json
@@ -39,5 +39,6 @@
   "0xdfdb7f72c1f195c5951a234e8db9806eb0635346": "https://etherscan.io/token/images/feistydoge_32.png",
   "0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81": "https://etherscan.io/token/images/dopexgovernance_32.png",
   "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72": "https://etherscan.io/token/images/ens2_32.png",
-  "0xf8e9f10c22840b613cda05a0c5fdb59a4d6cd7ef": "https://etherscan.io/token/images/dogsofelon_32.png"
+  "0xf8e9f10c22840b613cda05a0c5fdb59a4d6cd7ef": "https://etherscan.io/token/images/dogsofelon_32.png",
+  "0x25cf13fe02af9181cb5361bac4610e5c2e8b2519": "https://xfo.network/images/logo/xfo_token_logo.png"
 }


### PR DESCRIPTION
Adding the metadata and logo mapping for Wrapped 0xForce (wXFO) deployed natively on Arbitrum One (Chain ID 42161).

Contract Address: 0x25cf13fe02af9181cb5361bac4610e5c2e8b2519
Verified and compiled locally using yarn build and unit tests.