### PR TITLE
fix(generation): probe decimals before fetching name and symbol

### DIFF
--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -187,18 +187,35 @@ export const generateTokenList = async (
 
   const intermediateTokenData = [];
   for (const addrs of getChunks(l2AddressesFromL1, 100)) {
-    const tokenDataTemp = await promiseErrorMultiplier(
-      l2.multiCaller.getTokenData(
-        addrs.map((t) => t || constants.AddressZero),
-        { name: true, decimals: true, symbol: true },
-      ),
-      () =>
-        l2.multiCaller.getTokenData(
-          addrs.map((t) => t || constants.AddressZero),
-          { name: true, decimals: true, symbol: true },
-        ),
+    const targets = addrs.map((t) => t || constants.AddressZero);
+    // `decimals` alone tells us whether the child token exists, in one call per
+    // token. Asking for name and symbol up front triples child chain traffic and
+    // throws most of it away at the `decimals === undefined` check below, which
+    // exhausts the bandwidth quota of Orbit chains served by public RPCs.
+    const decimals = await promiseErrorMultiplier(
+      l2.multiCaller.getTokenData(targets, { decimals: true }),
+      () => l2.multiCaller.getTokenData(targets, { decimals: true }),
     );
-    intermediateTokenData.push(tokenDataTemp);
+    const deployed = targets.filter(
+      (_, i) => decimals[i].decimals !== undefined,
+    );
+    const named = deployed.length
+      ? await promiseErrorMultiplier(
+          l2.multiCaller.getTokenData(deployed, { name: true, symbol: true }),
+          () =>
+            l2.multiCaller.getTokenData(deployed, { name: true, symbol: true }),
+        )
+      : [];
+    let j = 0;
+    intermediateTokenData.push(
+      // `getTokenData` returns every field it knows about, so `decimals` has to
+      // win over the undefined one that comes back from the name/symbol call
+      decimals.map((datum) =>
+        datum.decimals === undefined
+          ? datum
+          : { ...named[j++], decimals: datum.decimals },
+      ),
+    );
   }
 
   const tokenData = intermediateTokenData.flat(1);


### PR DESCRIPTION
Orbit token list generation fails on bandwidth-capped public RPCs. SX's endpoint returns HTTP 429 `Bandwidth limit exceeded`, which ethers v5 surfaces as the misleading `missing revert data in call exception (data="0x")`.

The quota is on bytes, so smaller batches don't help. `getTokenData` issues one call per field, so name + decimals + symbol meant 3 calls per candidate: ~42k of ~71k child calls, nearly all discarded at the existing `decimals === undefined` check.

Now probes `decimals` first, fetching name/symbol only for deployed tokens. ~40% fewer child calls.